### PR TITLE
Fixes for larger archives: read values as unsigned & fix block count calc

### DIFF
--- a/TLOU PSARC Tool/Forms/FrmMain.cs
+++ b/TLOU PSARC Tool/Forms/FrmMain.cs
@@ -75,6 +75,8 @@ namespace TLOU_PSARC_Tool.Forms
                     File.WriteAllBytes(entry.Key, psarc.GetFile(entry.Key));
                     File.AppendAllText("FilesMap.txt", entry.Key + Environment.NewLine);
                     Print("Done\r\n");
+
+                    Application.DoEvents();
                 }
                 psarc.Dispose();
                 MessageBox.Show("Done!");


### PR DESCRIPTION
Thanks for the tool, nothing else seemed to work on the game files, but I noticed this would error on some of the larger archives.

Had a look into it and think this should fix those, seems to fully extract core.psarc now, and files all look like they're extracted fine (at least a bunch of .png files I checked looked valid), tried a few of the other larger psarcs and they all extracted without error too.

I didn't test the import feature though (using orbis-psarc.exe seems to work fine for the game), but did update that with fixes for Temp1/Temp2 fields so should hopefully work on larger archives too.

I had to comment out the for loop at https://github.com/amrshaheen61/TLOU_PSARC_Tool/blob/a297812d095327b3d1e9f3dfd641c92caf8fd3da/TLOU%20PSARC%20Tool/Core/Psarc.cs#L136-L147 for certain files to extract though, seems those files had 1st block decompressed (so psarc.ArraySize[compressedBlockSizeIndex] == 0), but then following blocks were compressed.

The rest of the code seems setup to handle decompressed blocks fine but this loop was breaking it somehow, not really sure what the loop is doing, but with it commented out the files that had issues seem to work fine now.

The `Application.DoEvents` call just helps keep app from freezing as often, can still happen sometimes though, not really sure what better way to fix it is... maybe making a command-line version of this could get around it.

---

E: just did a test of extracting all the games .psarcs with this and recreating them with `orbis-psarc create -IFilesMap.txt -o[out-file-name] -N`, to create uncompressed psarc files out of them, and game seems to load fine with those extracted-and-repacked files 😸 

Sadly didn't notice much load time difference, seemed about the same to me. I wonder if running it uncompressed might help with traversal stutter at all though.
(I didn't really get much stutter on my system so can't really say if it helps though, maybe someone that has that issue could try the same thing here - you can find `orbis-psarc.exe` inside "Fake_PKG_Tools_v1.5.1` pack.